### PR TITLE
Refactor UI - add pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,9 @@ import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import MainNavigation from './Components/navigation/MainNavigation';
 import SidebarNavigation from './Components/navigation/SidebarNavigation';
 import SendInvitation, {
-  meta as sendInvitationMeta,
+  menu as sendInvitationMenu,
 } from 'Pages/SendInvitation';
-import ManageFriend, { meta as manageFriendMeta } from 'Pages/ManageFriend';
+import ManageFriend, { menu as manageFriendMenu } from 'Pages/ManageFriend';
 
 const contentStyle = {
   paddingLeft: '10px',
@@ -42,9 +42,9 @@ const App: React.FunctionComponent<AppProps> = () => {
             <Col style={contentStyle}>
               <Row>
                 <Switch>
-                  <Route path={manageFriendMeta.to} component={ManageFriend} />
+                  <Route path={manageFriendMenu.to} component={ManageFriend} />
                   <Route
-                    path={sendInvitationMeta.to}
+                    path={sendInvitationMenu.to}
                     component={SendInvitation}
                   />
                 </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import './App.css';
+import { Row, Col } from 'antd';
+import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import MainNavigation from './Components/navigation/MainNavigation';
 import SidebarNavigation from './Components/navigation/SidebarNavigation';
-import { Row, Col } from 'antd';
-import AddFriendForm from 'Components/form/AddFriendForm';
-import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
+import SendInvitation, {
+  meta as sendInvitationMeta,
+} from 'Pages/SendInvitation';
+import ManageFriend, { meta as manageFriendMeta } from 'Pages/ManageFriend';
 
 const contentStyle = {
   paddingLeft: '10px',
@@ -12,6 +15,11 @@ const contentStyle = {
   overflow: 'auto',
   height: 'auto',
   minHeight: '400px',
+} as React.CSSProperties;
+
+const navigationStyle = {
+  width: '1024px',
+  margin: '0 auto',
 } as React.CSSProperties;
 
 type AppProps = {
@@ -29,17 +37,16 @@ const App: React.FunctionComponent<AppProps> = () => {
           }}
         >
           <MainNavigation />
-          <Row
-            style={{
-              width: '768px',
-              margin: '0 auto',
-            }}
-          >
+          <Row style={navigationStyle}>
             <SidebarNavigation />
             <Col style={contentStyle}>
               <Row>
                 <Switch>
-                  <Route path="/manage-friends" component={AddFriendForm} />
+                  <Route path={manageFriendMeta.to} component={ManageFriend} />
+                  <Route
+                    path={sendInvitationMeta.to}
+                    component={SendInvitation}
+                  />
                 </Switch>
               </Row>
             </Col>

--- a/src/Components/form/SendInvitationForm/SendInvitationForm.tsx
+++ b/src/Components/form/SendInvitationForm/SendInvitationForm.tsx
@@ -1,0 +1,83 @@
+import React, { FormEvent } from 'react';
+import { Form, Input, Button } from 'antd';
+import { FormComponentProps } from 'antd/lib/form';
+
+type Props = FormComponentProps;
+
+const SendInvitation: React.FunctionComponent<Props> = props => {
+  const { form } = props;
+
+  const tailFormItemLayout = {
+    wrapperCol: {
+      xs: {
+        span: 24,
+        offset: 0,
+      },
+      sm: {
+        span: 16,
+        offset: 0,
+      },
+    },
+  };
+
+  const formItemLayout = {
+    labelCol: {
+      xs: { span: 24 },
+      sm: { span: 6 },
+    },
+    wrapperCol: {
+      xs: { span: 24 },
+      sm: { span: 18 },
+    },
+  };
+
+  const validateEmail = (rule: any, value: any, callback: Function) => {
+    console.log({ rule, value, callback });
+    callback();
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const values = form.getFieldsValue();
+    console.log({ values });
+    form.validateFields((err, values) => {
+      console.log({ err, values });
+      if (!err) {
+        const { keys, names } = values;
+        console.log('Received values of form: ', values);
+        console.log('Merged values:', keys.map((key: string) => names[key]));
+      }
+    });
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Form.Item label="Email" {...formItemLayout}>
+        {form.getFieldDecorator('email', {
+          rules: [
+            {
+              required: true,
+              whitespace: true,
+              message: 'Please enter email of your friend',
+            },
+            {
+              validator: validateEmail,
+            },
+          ],
+        })(<Input placeholder="Email" />)}
+      </Form.Item>
+      <Form.Item {...tailFormItemLayout}>
+        <Button type="primary" htmlType="submit">
+          {' '}
+          Send Invitation{' '}
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+const SendInvitationForm = Form.create({ name: 'send_invitation' })(
+  SendInvitation
+);
+
+export default SendInvitationForm;

--- a/src/Components/form/SendInvitationForm/index.ts
+++ b/src/Components/form/SendInvitationForm/index.ts
@@ -1,0 +1,3 @@
+import SendInvitationForm from './SendInvitationForm';
+
+export default SendInvitationForm;

--- a/src/Components/form/index.ts
+++ b/src/Components/form/index.ts
@@ -1,0 +1,2 @@
+export { default as AddFriendForm } from './AddFriendForm';
+export { default as SendInvitationForm } from './SendInvitationForm';

--- a/src/Components/navigation/MainNavigation/MainNavigation.tsx
+++ b/src/Components/navigation/MainNavigation/MainNavigation.tsx
@@ -17,11 +17,6 @@ const MainNavigation: React.FunctionComponent = () => {
             Home
           </Link>
         </li>
-        <li style={{ marginRight: '10px', textAlign: 'center' }}>
-          <Link to="/send-invitation" style={style.defaultLink}>
-            Send Invitations
-          </Link>
-        </li>
         <li style={{ marginRight: '0', textAlign: 'center' }}>
           <Link to="/logout" style={style.metroUILink}>
             Logout

--- a/src/Components/navigation/MainNavigation/MainNavigation.tsx
+++ b/src/Components/navigation/MainNavigation/MainNavigation.tsx
@@ -3,8 +3,8 @@ import style from './style';
 import { Link } from 'react-router-dom';
 
 const mainNavigationStyle = {
-  minWidth: '768px',
-  width: '768px',
+  minWidth: '1024px',
+  width: '1024px',
   margin: '0 auto',
 } as React.CSSProperties;
 
@@ -18,7 +18,7 @@ const MainNavigation: React.FunctionComponent = () => {
           </Link>
         </li>
         <li style={{ marginRight: '10px', textAlign: 'center' }}>
-          <Link to="/send-invitations" style={style.defaultLink}>
+          <Link to="/send-invitation" style={style.defaultLink}>
             Send Invitations
           </Link>
         </li>

--- a/src/Components/navigation/SidebarNavigation/SidebarNavigation.tsx
+++ b/src/Components/navigation/SidebarNavigation/SidebarNavigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { meta as sendInvitation } from 'Pages/SendInvitation';
-import { meta as manageFriend } from 'Pages/ManageFriend';
+import { menu as sendInvitationMenu } from 'Pages/SendInvitation';
+import { menu as manageFriendMenu } from 'Pages/ManageFriend';
 
 const sideNavigation = {
   listStyle: 'none',
@@ -14,10 +14,10 @@ const SidebarNavigation: React.FunctionComponent = () => {
   return (
     <ul style={sideNavigation}>
       <li>
-        <Link to={manageFriend.to}>{manageFriend.label}</Link>
+        <Link to={manageFriendMenu.to}>{manageFriendMenu.label}</Link>
       </li>
       <li>
-        <Link to={sendInvitation.to}>{sendInvitation.label}</Link>
+        <Link to={sendInvitationMenu.to}>{sendInvitationMenu.label}</Link>
       </li>
       {/*<li>
         <Link to="/show-transactions">Show Transactions</Link>

--- a/src/Components/navigation/SidebarNavigation/SidebarNavigation.tsx
+++ b/src/Components/navigation/SidebarNavigation/SidebarNavigation.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { meta as sendInvitation } from 'Pages/SendInvitation';
+import { meta as manageFriend } from 'Pages/ManageFriend';
 
 const sideNavigation = {
   listStyle: 'none',
@@ -12,17 +14,17 @@ const SidebarNavigation: React.FunctionComponent = () => {
   return (
     <ul style={sideNavigation}>
       <li>
-        <Link to="/manage-friends">Manage Friends List</Link>
+        <Link to={manageFriend.to}>{manageFriend.label}</Link>
       </li>
       <li>
-        <Link to="/send-invitations">Send invitations</Link>
+        <Link to={sendInvitation.to}>{sendInvitation.label}</Link>
       </li>
-      <li>
+      {/*<li>
         <Link to="/show-transactions">Show Transactions</Link>
       </li>
       <li>
         <Link to="/show-graph">Show Graph</Link>
-      </li>
+      </li>*/}
     </ul>
   );
 };

--- a/src/Pages/ManageFriend.tsx
+++ b/src/Pages/ManageFriend.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import AddFriendForm from 'Components/form/AddFriendForm';
+
+export const meta = {
+  to: '/manage-friend',
+  label: 'Manage Friend',
+};
+
+type Props = {};
+
+const ManageFriend: React.FunctionComponent<Props> = () => {
+  return <AddFriendForm />;
+};
+
+export default ManageFriend;

--- a/src/Pages/ManageFriend.tsx
+++ b/src/Pages/ManageFriend.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import AddFriendForm from 'Components/form/AddFriendForm';
+import { AddFriendForm } from 'Components/form';
 
 export const meta = {
-  to: '/manage-friend',
-  label: 'Manage Friend',
+  to: '/add-friend',
+  label: 'Add friend',
 };
 
 type Props = {};

--- a/src/Pages/ManageFriend.tsx
+++ b/src/Pages/ManageFriend.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AddFriendForm } from 'Components/form';
 
-export const meta = {
+export const menu = {
   to: '/add-friend',
   label: 'Add friend',
 };

--- a/src/Pages/SendInvitation.tsx
+++ b/src/Pages/SendInvitation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SendInvitationForm } from 'Components/form';
 
-export const meta = {
+export const menu = {
   to: '/send-invitation',
   label: 'Send Invitation',
 };

--- a/src/Pages/SendInvitation.tsx
+++ b/src/Pages/SendInvitation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SendInvitationForm } from 'Components/form';
 
 export const meta = {
   to: '/send-invitation',
@@ -8,7 +9,7 @@ export const meta = {
 type Props = {};
 
 const SendInvitation: React.FunctionComponent<Props> = () => {
-  return <h1>Send Invitations</h1>;
+  return <SendInvitationForm />;
 };
 
 export default SendInvitation;

--- a/src/Pages/SendInvitation.tsx
+++ b/src/Pages/SendInvitation.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const meta = {
+  to: '/send-invitation',
+  label: 'Send Invitation',
+};
+
+type Props = {};
+
+const SendInvitation: React.FunctionComponent<Props> = () => {
+  return <h1>Send Invitations</h1>;
+};
+
+export default SendInvitation;

--- a/src/Pages/index.ts
+++ b/src/Pages/index.ts
@@ -1,0 +1,5 @@
+import SendInvitation from './SendInvitation';
+
+export default {
+  SendInvitation,
+};


### PR DESCRIPTION
- all links and pages are moved to Pages folder.

Basic structure for any Page component will be similar to as shown below. 

```
import React from 'react';
import { AddFriendForm } from 'Components/form';

export const menu = {
  to: '/add-friend',
  label: 'Add friend',
};

type Props = {};

const ManageFriend: React.FunctionComponent<Props> = () => {
  return <AddFriendForm />;
};

export default ManageFriend;
```

Import Page component as shown below. The benefit is that link and label for page will be responsibility of Page Component. 

```
import ManageFriend, { menu as manageFriendMenu } from 'Pages/ManageFriend';
```

`menu` will contain the page url and label that will be used as menu link.

This page will be linked to Route as shown below.

```
<Switch>
  <Route path={manageFriendMenu.to} component={ManageFriend} />
  ...
  // More Routes here
</Switch>
```

Link to list

```
        <Link to={manageFriendMenu.to}>{manageFriendMenu.label}</Link>
```
