### PR TITLE
closes #43 Fix flickering of sider context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import SendInvitation, {
@@ -20,6 +20,7 @@ import {
 import AddNewItem, { menu as addNewItemMenu } from 'Pages/AddNewItem';
 import Dashboard, { menu as dashboardMenu } from 'Pages/Dashboard';
 import { hot } from 'react-hot-loader/root';
+import { SiderContext } from 'Components/context';
 
 type Props = {
   loggedIn?: boolean;
@@ -42,25 +43,40 @@ const App: React.FunctionComponent<Props> = () => {
   //   );
   // }
 
+  const collapsed = localStorage.getItem('menu.is_collapsed');
+  const openState = collapsed === 'yes';
+  const [siderState, setSiderState] = useState(openState);
+
   return (
-    <Provider store={store}>
-      <Router>
-        <Switch>
-          <Route path={dashboardMenu.to} component={Dashboard} />
-          <Route path={addFriendMenu.to} component={AddFriend} />
-          <Route path={addNewItemMenu.to} component={AddNewItem} />
-          <Route path={sendInvitationMenu.to} component={SendInvitation} />
-          <Route path={transactionMenu.to} component={TransactionList} />
-          <Route path="/transaction/:id/edit" component={TransactionEdit} />
-          <Route path="/settings" component={Settings} />
-          <Route path="/profile" component={Profile} />
-          <Route path="/summary">
-            <ComingSoon title="Summary" />
-          </Route>
-          <Route component={PageNotFound} />
-        </Switch>
-      </Router>
-    </Provider>
+    <Router>
+      <Provider store={store}>
+        <SiderContext.Provider
+          value={{
+            collapsed: siderState,
+            toggleSider: () => {
+              const newValue = collapsed === 'yes' ? 'no' : 'yes';
+              localStorage.setItem('menu.is_collapsed', newValue);
+              setSiderState(!siderState);
+            },
+          }}
+        >
+          <Switch>
+            <Route path={dashboardMenu.to} component={Dashboard} />
+            <Route path={addFriendMenu.to} component={AddFriend} />
+            <Route path={addNewItemMenu.to} component={AddNewItem} />
+            <Route path={sendInvitationMenu.to} component={SendInvitation} />
+            <Route path={transactionMenu.to} component={TransactionList} />
+            <Route path="/transaction/:id/edit" component={TransactionEdit} />
+            <Route path="/settings" component={Settings} />
+            <Route path="/profile" component={Profile} />
+            <Route path="/summary">
+              <ComingSoon title="Summary" />
+            </Route>
+            <Route component={PageNotFound} />
+          </Switch>
+        </SiderContext.Provider>
+      </Provider>
+    </Router>
   );
 };
 

--- a/src/Components/context/SiderContext/SiderContext.ts
+++ b/src/Components/context/SiderContext/SiderContext.ts
@@ -1,8 +1,10 @@
 import React from 'react';
 
-export const SiderContext = React.createContext({
+export const SiderContext = React.createContext<SiderContextValue>({
   collapsed: false,
   toggleSider: () => {},
 });
 
 SiderContext.displayName = 'SiderContext';
+
+export default SiderContext;

--- a/src/Components/context/SiderContext/index.ts
+++ b/src/Components/context/SiderContext/index.ts
@@ -1,1 +1,3 @@
-export { SiderContext } from './SiderContext';
+import SiderContext from './SiderContext';
+
+export default SiderContext;

--- a/src/Components/context/index.ts
+++ b/src/Components/context/index.ts
@@ -1,0 +1,1 @@
+export { default as SiderContext } from './SiderContext';

--- a/src/Components/form/ProfileForm/ProfileForm.tsx
+++ b/src/Components/form/ProfileForm/ProfileForm.tsx
@@ -1,7 +1,6 @@
 import React, { FormEvent } from 'react';
 import { Icon, message, Form, Input, Button } from 'antd';
 import { FormComponentProps } from 'antd/lib/form';
-import moment from 'moment';
 import { RouteComponentProps } from 'react-router-dom';
 
 type Props = FormComponentProps & RouteComponentProps;
@@ -50,10 +49,6 @@ const PForm: React.FunctionComponent<Props> = props => {
   };
 
   const { getFieldDecorator } = form;
-
-  function onChange(date: moment.Moment | null, dateString: string) {
-    console.log(date, dateString);
-  }
 
   return (
     <Form {...formItemLayout} onSubmit={onFormSubmit}>

--- a/src/Components/logo/SidebarMenuLogo/SidebarMenuLogo.tsx
+++ b/src/Components/logo/SidebarMenuLogo/SidebarMenuLogo.tsx
@@ -1,38 +1,19 @@
 import React from 'react';
 import styled from 'styled-components';
 
-type LogoTypeSmall = 'small';
-type LogoTypeDefault = 'default';
-
 type LogoProps = {
-  type?: LogoTypeSmall | LogoTypeDefault;
+  src: string;
+  alt?: string;
   width?: number;
   height?: number;
+  title?: string;
 };
 
-const SidebarMenuLogo: React.FunctionComponent<LogoProps> = props => {
-  const { type } = props;
-  const localProps = Object.assign({}, props);
-  delete localProps['type'];
-
-  if (type === 'small') {
-    return (
-      <StyledMenuLogo
-        {...localProps}
-        src="/img/sidebarmenu-logo-74x45.jpg"
-        alt="collapsed application logo"
-      />
-    );
-  }
-
-  return (
-    <StyledMenuLogo
-      {...props}
-      src="/img/sidebarmenu-logo-192x45.jpg"
-      alt="expanded application logo"
-    />
-  );
-};
+const SidebarMenuLogo: React.FunctionComponent<LogoProps> = ({
+  src = '/img/sidebarmenu-logo-74x45.jpg',
+  alt = 'application logo',
+  ...props
+}) => <StyledMenuLogo {...props} src={src} alt={alt} />;
 
 const StyledMenuLogo = styled('img')`
   height: 32px;

--- a/src/Components/menu/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/Components/menu/HamburgerMenu/HamburgerMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SiderContext } from 'Components/context/SiderContext';
+import { SiderContext } from 'Components/context';
 import { Button } from 'antd';
 
 type Props = {};

--- a/src/Layout/DashboardPageLayout.tsx
+++ b/src/Layout/DashboardPageLayout.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 import { Layout } from 'antd';
 import SidebarMenuLogo from 'Components/logo/SidebarMenuLogo';
 import { AppFooter } from 'Components/section';
 import AppMenu from 'Components/menu/AppMenu/AppMenu';
 import { DashboardHeader } from 'Components';
-import { SiderContext } from 'Components/context/SiderContext';
+import { SiderContext } from 'Components/context';
+import styled from 'styled-components';
 
 const { Sider } = Layout;
 
@@ -15,56 +16,41 @@ type CommonLayoutProps = {
 const DashboardPageLayout: React.FunctionComponent<CommonLayoutProps> = ({
   children,
 }) => {
-  const siderOpenContext = useContext(SiderContext);
-  const [collapsed, setCollapsed] = useState(siderOpenContext.collapsed);
-
-  const onCollapse = (isCollapsed: boolean) => {
-    localStorage.setItem('menu.is_collapsed', isCollapsed ? 'yes' : 'no');
-
-    setCollapsed(isCollapsed);
-  };
-
-  useEffect(() => {
-    const isCollapsed = localStorage.getItem('menu.is_collapsed') === 'yes';
-
-    setCollapsed(isCollapsed);
-  }, []);
-
-  const initialState = {
-    collapsed: collapsed,
-    toggleSider: () => {
-      const toggled = !collapsed;
-      setCollapsed(toggled);
-      localStorage.setItem(
-        'menu.is_collapsed',
-        toggled === true ? 'yes' : 'no'
-      );
-    },
-  };
+  const siderState = useContext(SiderContext);
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <SiderContext.Provider value={initialState}>
-        <Sider
-          collapsible
-          collapsed={collapsed}
-          onCollapse={onCollapse}
-          width={220}
-        >
-          {!collapsed && <SidebarMenuLogo />}
-          {collapsed && <SidebarMenuLogo type="small" />}
-          <AppMenu />
-        </Sider>
-      </SiderContext.Provider>
+    <DashboardLayout>
+      <Sider
+        collapsible
+        collapsed={siderState.collapsed}
+        onCollapse={siderState.toggleSider}
+        width={220}
+      >
+        {!siderState.collapsed && (
+          <SidebarMenuLogo
+            src="/img/sidebarmenu-logo-192x45.jpg"
+            alt="expanded application logo"
+          />
+        )}
+        {siderState.collapsed && (
+          <SidebarMenuLogo
+            src="/img/sidebarmenu-logo-74x45.jpg"
+            alt="collapsed application logo"
+          />
+        )}
+        <AppMenu />
+      </Sider>
       <Layout>
-        <SiderContext.Provider value={initialState}>
-          <DashboardHeader />
-        </SiderContext.Provider>
+        <DashboardHeader />
         {children}
         <AppFooter />
       </Layout>
-    </Layout>
+    </DashboardLayout>
   );
 };
+
+const DashboardLayout = styled(Layout)`
+  min-height: 100vh;
+`;
 
 export default DashboardPageLayout;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-// import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 

--- a/src/types/SiderContextValue.d.ts
+++ b/src/types/SiderContextValue.d.ts
@@ -1,0 +1,4 @@
+type SiderContextValue = {
+  collapsed: boolean;
+  toggleSider: () => void;
+};


### PR DESCRIPTION
Left side menu was flickering as the collapse and expand was happening very late after render of component. Now, component renders only after we have enough information about collapse or expand state for Left side Menu (Sider Menu)