### PR TITLE
Fixed tty error in docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - "traefik.http.services.whofrontend.loadBalancer.server.port=8000"
       - "traefik.http.routers.whofrontend.entrypoints=web"
     command: "npm run start"
-    tty: "true"
+    tty: true
 
   whoapi:
     container_name: "whoapi"


### PR DESCRIPTION
Fixes the tty error during starting docker by `docker-compose up -d`.